### PR TITLE
MTLS with CA validation

### DIFF
--- a/Kritner.Mtls.sln
+++ b/Kritner.Mtls.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29806.167
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kritner.Mtls", "src\Kritner.Mtls.csproj", "{F377452F-9308-4969-AC14-C5657F810914}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kritner.Mtls", "src\Kritner.Mtls\Kritner.Mtls.csproj", "{8EC45A00-F2DF-406D-881B-933F28CF5251}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Kritner.Mtls.Core", "src\Kritner.Mtls.Core\Kritner.Mtls.Core.csproj", "{A92799E6-6F63-4531-9F5C-2358D8334F3D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,10 +13,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F377452F-9308-4969-AC14-C5657F810914}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F377452F-9308-4969-AC14-C5657F810914}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F377452F-9308-4969-AC14-C5657F810914}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F377452F-9308-4969-AC14-C5657F810914}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8EC45A00-F2DF-406D-881B-933F28CF5251}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8EC45A00-F2DF-406D-881B-933F28CF5251}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8EC45A00-F2DF-406D-881B-933F28CF5251}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8EC45A00-F2DF-406D-881B-933F28CF5251}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A92799E6-6F63-4531-9F5C-2358D8334F3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A92799E6-6F63-4531-9F5C-2358D8334F3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A92799E6-6F63-4531-9F5C-2358D8334F3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A92799E6-6F63-4531-9F5C-2358D8334F3D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Kritner.Mtls.Core/CertificateAuthorityValidator.cs
+++ b/src/Kritner.Mtls.Core/CertificateAuthorityValidator.cs
@@ -1,0 +1,70 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Numerics;
+using System.Security.Cryptography.X509Certificates;
+using System.Linq;
+
+namespace Kritner.Mtls.Core
+{
+    public class CertificateAuthorityValidator : ICertificateAuthorityValidator
+    {
+        private readonly ILogger<CertificateAuthorityValidator> _logger;
+
+        // this should probably be injected via config or loaded from the cert
+        // Apparently the bytes are in the reverse order when using this BigInteger parse method,
+        // hence the reverse
+        private readonly byte[] _caCertSubjectKeyIdentifier = BigInteger.Parse(
+            "e9be86f64eb53bc12c1b5fe0f63df450274811da",
+            System.Globalization.NumberStyles.HexNumber
+        ).ToByteArray().Reverse().ToArray();
+
+        private const string AuthorityKeyIdentifier = "Authority Key Identifier";
+        
+        public CertificateAuthorityValidator(ILogger<CertificateAuthorityValidator> logger)
+        {
+            _logger = logger;
+        }
+
+        public bool IsValid(X509Certificate2 clientCert)
+        {
+            _logger.LogInformation($"Validating certificate within the {nameof(CertificateAuthorityValidator)}");
+            
+            if (clientCert == null)
+                return false;
+            foreach (var extension in clientCert.Extensions)
+            {
+                if (extension.Oid.FriendlyName.Equals(AuthorityKeyIdentifier, StringComparison.OrdinalIgnoreCase))
+                {
+                    try
+                    {
+                        var authorityKeyIdentifier = new byte[_caCertSubjectKeyIdentifier.Length];
+                        // Copy from the extension raw data, starting at the index that should be after the "KeyID=" bytes
+                        Array.Copy(
+                            extension.RawData, extension.RawData.Length - _caCertSubjectKeyIdentifier.Length, 
+                            authorityKeyIdentifier, 0, 
+                            authorityKeyIdentifier.Length);
+
+                        if (_caCertSubjectKeyIdentifier.SequenceEqual(authorityKeyIdentifier))
+                        {
+                            _logger.LogInformation("Successfully validated the certificate came from the intended CA.");
+                            return true;
+                        }
+                        else
+                        {
+                            _logger.LogError($"Client cert with subject '{clientCert.Subject}' not signed by our CA.");
+                            return false;
+                        }
+                    }
+                    catch (Exception e)
+                    {
+                        _logger.LogError(e, string.Empty);
+                        return false;
+                    }
+                }
+            }
+            
+            _logger.LogError($"'{clientCert.Subject}' did not contain the extension to check for CA validity.");
+            return false;
+        }
+    }
+}

--- a/src/Kritner.Mtls.Core/ICertificateAuthorityValidator.cs
+++ b/src/Kritner.Mtls.Core/ICertificateAuthorityValidator.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Kritner.Mtls.Core
+{
+    public interface ICertificateAuthorityValidator
+    {
+        bool IsValid(X509Certificate2 clientCert);
+    }
+}

--- a/src/Kritner.Mtls.Core/Kritner.Mtls.Core.csproj
+++ b/src/Kritner.Mtls.Core/Kritner.Mtls.Core.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.6" />
+  </ItemGroup>
+
+</Project>

--- a/src/Kritner.Mtls/Kritner.Mtls.csproj
+++ b/src/Kritner.Mtls/Kritner.Mtls.csproj
@@ -8,4 +8,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Certificate" Version="3.1.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Kritner.Mtls.Core\Kritner.Mtls.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/Kritner.Mtls/Program.cs
+++ b/src/Kritner.Mtls/Program.cs
@@ -1,5 +1,7 @@
+using Kritner.Mtls.Core;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Https;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Kritner.Mtls
@@ -13,6 +15,10 @@ namespace Kritner.Mtls
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .ConfigureServices(serviceCollection =>
+                {
+                    serviceCollection.AddSingleton<ICertificateAuthorityValidator, CertificateAuthorityValidator>();
+                })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();


### PR DESCRIPTION
- Introduces new CA validation service that is fired off after `OnCertificateValidated`
- CA validation service checks to ensure that the intended CA signed the client cert that was provided
  - it does this via a (currently) hardcoded [Subject Key Identifier](https://knowledge.digicert.com/solution/SO18140#SKI) and comparing it to the client certificate [Authority Key Identifier](https://knowledge.digicert.com/solution/SO18140#AKI)
  - The SKI should probably be injected in via `IOptions<T>` or some other provider, but this was a quicker way to demonstrate